### PR TITLE
Add the subpath for /archive so that the correct css is loaded

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ email: rls890@vu.nl
 description: > # this means to ignore newlines until "baseurl:"
   The homepage for the mathlib library for the Lean theorem prover.
   Contains an archive of the Zulip chat for discussions about Lean and mathlib.
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/archive" # the subpath of your site, e.g. /blog
 url: "https://leanprover-community.github.io" # the base hostname & protocol for your site
 
 # Build settings


### PR DESCRIPTION
Currently https://github.com/leanprover-community/archive/blob/master/_includes/head.html#L13 loads css via `  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl | prepend: site.url }}">` which results in <https://leanprover-community.github.io/css/main.css> rather than <https://leanprover-community.github.io/archive/css/main.css> .

The fixed version is visible at https://alexjbest.github.io/archive/